### PR TITLE
Fix #1

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -54,8 +54,13 @@ fn main() {
         }
     }
 
-    println!("cargo:rustc-link-lib=static=tcc");
+    if target.contains("msvc") {
+        println!("cargo:rustc-link-lib=static=libtcc");
+    } else {
+        println!("cargo:rustc-link-lib=static=tcc");
+    }
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=LIB_TCC");
 }
 
 fn build_tcc(config_arg: Option<&[&str]>, make_arg: Option<&[&str]>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -531,6 +531,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_env = "msvc"))]
     fn link_lib() {
         let p = CString::new(
             r#"


### PR DESCRIPTION
I added an if statement that prints the correct library version if MSVC is the target. Also, build.rs should now react to changes in the environment variable LIB_TCC.

One testcase (using a library) I could not get to work on windows-msvc, so I disabled it for now.