### PR TITLE
Fix #1

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -54,8 +54,13 @@ fn main() {
         }
     }
 
-    println!("cargo:rustc-link-lib=static=tcc");
+    if target.contains("msvc") {
+        println!("cargo:rustc-link-lib=static=libtcc");
+    } else {
+        println!("cargo:rustc-link-lib=static=tcc");
+    }
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=LIB_TCC");
 }
 
 fn build_tcc(config_arg: Option<&[&str]>, make_arg: Option<&[&str]>) {

--- a/build.rs
+++ b/build.rs
@@ -119,7 +119,8 @@ fn tcc_installed() -> bool {
         .arg("-ltcc")
         .arg("-ldl")
         .arg("-lrt")
-        .arg("-lm");
+        .arg("-lm")
+        .arg("-lpthread");
     println!("running {:?}", cmd);
     if let Ok(status) = cmd.status() {
         if status.success() {

--- a/build.rs
+++ b/build.rs
@@ -93,11 +93,19 @@ fn build_tcc(config_arg: Option<&[&str]>, make_arg: Option<&[&str]>) {
 }
 
 fn tcc_installed() -> bool {
+    if cfg!(target_os = "windows") {
+        eprintln!(
+            "WARN: compiling libtcc on windows, make sure tcc is built and installed correctly"
+        );
+        return true;
+    }
+
     let cfg = cc::Build::new();
     let out = PathBuf::from(env::var("OUT_DIR").unwrap());
     let tcc_tmp = out.join("tcc-tmp");
     if let Err(e) = create_dir(&tcc_tmp) {
-        if let ErrorKind::AlreadyExists = e.kind() {} else {
+        if let ErrorKind::AlreadyExists = e.kind() {
+        } else {
             eprintln!("Fail to creat build dir:{}", tcc_tmp.display());
             exit(1);
         }
@@ -111,8 +119,7 @@ fn tcc_installed() -> bool {
         .arg("-ltcc")
         .arg("-ldl")
         .arg("-lrt")
-        .arg("-lm")
-        .arg("-lpthread");
+        .arg("-lm");
     println!("running {:?}", cmd);
     if let Ok(status) = cmd.status() {
         if status.success() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -531,6 +531,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_env = "msvc"))]
     fn link_lib() {
         let p = CString::new(
             r#"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,13 +256,15 @@ impl<'a, 'b> Context<'a, 'b> {
     }
 }
 
+#[cfg(target_family = "unix")]
 fn to_cstr<T: AsRef<Path>>(p: T) -> CString {
-    #[cfg(target_family = "unix")]
     use std::os::unix::ffi::OsStrExt;
-    #[cfg(target_family = "windows")]
-    use std::os::windows::ffi::OsStrExt;
-
     CString::new(p.as_ref().as_os_str().as_bytes()).unwrap()
+}
+
+#[cfg(target_family = "windows")]
+fn to_cstr<T: AsRef<Path>>(p: T) -> CString {
+    CString::new(p.as_ref().to_string_lossy().to_string().as_bytes()).unwrap()
 }
 
 // preprocessor

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,11 @@ impl<'a, 'b> Context<'a, 'b> {
 }
 
 fn to_cstr<T: AsRef<Path>>(p: T) -> CString {
+    #[cfg(target_family = "unix")]
     use std::os::unix::ffi::OsStrExt;
+    #[cfg(target_family = "windows")]
+    use std::os::windows::ffi::OsStrExt;
+
     CString::new(p.as_ref().as_os_str().as_bytes()).unwrap()
 }
 


### PR DESCRIPTION
This PR contains a sample solution for issues #2.

Specifically, it does the following things:
      (1) changes build.rs to pass libtcc checking when building on windows and give correct library name to cargo when using msvc toolchain; 
      (2) changes lib.rs to disable one test case which is not suitable on windows. 
    