### PR TITLE
Fix segmentation fault when calling tcc_relocate multiple times

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -1,6 +1,6 @@
 name: CI (Linux)
 
-on: [push, pull_request]
+on: [push, pull_request ]
 
 jobs:
   build_and_test:
@@ -16,13 +16,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
-     
+
       - name: install-deps
         run: sudo apt update && sudo apt install gcc-multilib g++-multilib
 
       - name: install-tcc-0.9.27
         run: git clone https://github.com/TinyCC/tinycc.git tcc && cd tcc && git checkout tags/release_0_9_27 -b release_0_9_27 && ./configure && make && sudo make install && cd ../
- 
+
       - name: Install ${{ matrix.version }}
         uses: actions-rs/toolchain@v1
         with:
@@ -34,25 +34,25 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: generate-lockfile
-      
+
       - name: Cache cargo registry
         uses: actions/cache@v1
         with:
           path: ~/.cargo/registry
           key: ${{ matrix.version }}-x86_64-unknown-linux-gnu-cargo-registry-trimmed-${{ hashFiles('**/Cargo.lock') }}
-      
+
       - name: Cache cargo index
         uses: actions/cache@v1
         with:
           path: ~/.cargo/git
           key: ${{ matrix.version }}-x86_64-unknown-linux-gnu-cargo-index-trimmed-${{ hashFiles('**/Cargo.lock') }}
-      
+
       - name: Cache cargo build
         uses: actions/cache@v1
         with:
           path: target
           key: ${{ matrix.version }}-x86_64-unknown-linux-gnu-cargo-build-trimmed-${{ hashFiles('**/Cargo.lock') }}
-      
+
 
       - name: check build
         uses: actions-rs/cargo@v1
@@ -72,7 +72,7 @@ jobs:
         run: |
           cargo install cargo-tarpaulin
           cargo tarpaulin --out Xml -- --test-threads=1
-      
+
       - name: Upload to Codecov
         if: matrix.version == 'stable' && (github.ref == 'refs/heads/master' || github.event_name == 'pull_request')
         uses: codecov/codecov-action@v1

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -1,6 +1,6 @@
 name: CI (Linux)
 
-on: [push, pull_request ]
+on: [push, pull_request]
 
 jobs:
   build_and_test:
@@ -16,13 +16,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
-
+     
       - name: install-deps
         run: sudo apt update && sudo apt install gcc-multilib g++-multilib
 
       - name: install-tcc-0.9.27
         run: git clone https://github.com/TinyCC/tinycc.git tcc && cd tcc && git checkout tags/release_0_9_27 -b release_0_9_27 && ./configure && make && sudo make install && cd ../
-
+ 
       - name: Install ${{ matrix.version }}
         uses: actions-rs/toolchain@v1
         with:
@@ -34,25 +34,25 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: generate-lockfile
-
+      
       - name: Cache cargo registry
         uses: actions/cache@v1
         with:
           path: ~/.cargo/registry
           key: ${{ matrix.version }}-x86_64-unknown-linux-gnu-cargo-registry-trimmed-${{ hashFiles('**/Cargo.lock') }}
-
+      
       - name: Cache cargo index
         uses: actions/cache@v1
         with:
           path: ~/.cargo/git
           key: ${{ matrix.version }}-x86_64-unknown-linux-gnu-cargo-index-trimmed-${{ hashFiles('**/Cargo.lock') }}
-
+      
       - name: Cache cargo build
         uses: actions/cache@v1
         with:
           path: target
           key: ${{ matrix.version }}-x86_64-unknown-linux-gnu-cargo-build-trimmed-${{ hashFiles('**/Cargo.lock') }}
-
+      
 
       - name: check build
         uses: actions-rs/cargo@v1
@@ -72,7 +72,7 @@ jobs:
         run: |
           cargo install cargo-tarpaulin
           cargo tarpaulin --out Xml -- --test-threads=1
-
+      
       - name: Upload to Codecov
         if: matrix.version == 'stable' && (github.ref == 'refs/heads/master' || github.event_name == 'pull_request')
         uses: codecov/codecov-action@v1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,25 +232,15 @@ impl<'a, 'b> Context<'a, 'b> {
 
     /// do all relocations (needed before get symbol)
     pub fn relocate(mut self) -> Result<RelocatedCtx, ()> {
-        // pass null ptr to get required length
-        let len = unsafe { tcc_relocate(self.inner, null_mut()) };
-        if len == -1 {
-            return Err(());
-        };
-        let mut bin = Vec::with_capacity(len as usize);
-        let ret = unsafe { tcc_relocate(self.inner, bin.as_mut_ptr() as *mut c_void) };
+        let ret = unsafe { tcc_relocate(self.inner, 1 as *mut c_void) };
         if ret != 0 {
             return Err(());
-        }
-        unsafe {
-            bin.set_len(len as usize);
         }
         let tcc_handle = self.inner;
         self.inner = null_mut();
 
         Ok(RelocatedCtx {
             inner: tcc_handle,
-            _bin: bin,
             phantom: PhantomData,
         })
     }
@@ -287,7 +277,6 @@ fn map_c_ret(code: c_int) -> Result<(), ()> {
 /// Relocated compilation context
 pub struct RelocatedCtx {
     inner: *mut TCCState,
-    _bin: Vec<u8>,
     phantom: PhantomData<TCCState>,
 }
 


### PR DESCRIPTION
When trying to use "Context::relocate" multiple times in certain situations causes a segmentation fault, I don't know the exact reason why, but I guess it is memory management related, because:
* When putting a `mem::forget(bin)` after the `let ret = unsafe { tcc_relocate(self.inner, bin.as_mut_ptr() as *mut c_void) };` on line 241 seems to patch that segfault.
* Another way I found of avoiding the segfault is to only free all of the context at the same time at the end of the program. This avoids using relocate after a context has been freed and messed up.
* Looking at a coredump, I saw that it segfaults in a malloc call.

My solution is to let libtcc handle to memory of the relocated code by passing `TCC_RELOCATE_AUTO` as the address on where to save the relocated code. This will tell libtcc to keep track of the relocated code internally and to free it at the end when calling `tcc_delete`.

The segfault can be recreated by taking the example `greet.rs` program provided and wrapping the creation of the context and relocating in a loop. This causes the context to be freed at the end of each loop, and then cause problems on the next loop.

Here is the modified `greet.rs` that reproduces the segfault:
<details>

```rust
use libtcc::*;
use std::ffi::{CStr, CString};
use std::mem::transmute;
use std::process::exit;

static GREET: &str = r#"
#include <stdio.h>
void greet(){
    printf("hello, rust\n");
}
"#;

fn main() {
    let c_program = CString::new(GREET.as_bytes()).unwrap();
    let mut err_warn = None;

    let mut g = Guard::new().unwrap();
    for i in 1..10 {
	    let mut ctx = Context::new(&mut g).unwrap();
    
	    let compile_ret = ctx
                .set_output_type(OutputType::Memory)
                .set_call_back(|msg| err_warn = Some(String::from(msg.to_str().unwrap())))
                .compile_string(&c_program);
	    if compile_ret.is_err() {
                drop(ctx);
                eprintln!("{:?}", err_warn);
                exit(1);
	    }
    
	    let mut relocated = ctx.relocate().unwrap();
	    let addr = unsafe {
                relocated
                    .get_symbol(CStr::from_bytes_with_nul_unchecked("greet\0".as_bytes()))
                    .unwrap()
	    };
	    let greet: fn() = unsafe { transmute(addr) };
	    greet();
    }
}

```
</details>

Here is the output of that modified `greet.rs`:
```
> cargo run --example greet
hello, rust
zsh: segmentation fault  cargo run --example greet
```

