### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -8,12 +8,11 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.40.0 
           - stable
           - nightly
 
     name: ${{ matrix.version }} - x86_64-unknown-linux-gnu
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@master
@@ -22,7 +21,7 @@ jobs:
         run: sudo apt update && sudo apt install gcc-multilib g++-multilib
 
       - name: install-tcc-0.9.27
-        run: git clone https://github.com/TinyCC/tinycc.git tcc  && cd tcc && ./configure && make && sudo make install && cd ../
+        run: git clone https://github.com/TinyCC/tinycc.git tcc && cd tcc && git checkout tags/release_0_9_27 -b release_0_9_27 && ./configure && make && sudo make install && cd ../
  
       - name: Install ${{ matrix.version }}
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
So, libtcc-0.9.27 C library was broken due to the breaking changes introduced in glibc-2.34, which completely removed the support for the `__malloc_hook` variable that libtcc-0.9.27 depends on (see [bcheck.c](https://github.com/TinyCC/tinycc/blob/d348a9a51d32cece842b7885d27a411436d7887b/lib/bcheck.c#L738)).

We can fix this in two ways: 1) upgrade the libtcc we depend on to a version that can be built with the latest gcc toolchains, this 4461f38a9e78 commit did this; 2) limit the glibc version (before 2.34) for build and depend on the stable 0.9.27. We choose the second. The first way is not feasible because the libtcc C library after the 4461f38a9e78 commit is not compatible with rust applications possibly due to its way of bound checking, which causes segment fault when calling libtcc API from rust to C. The bisect also did not find any compatible version after 4461f38a9e78. Therefore, depending on stable 0.9.27 and using older glibc is the only option.